### PR TITLE
fix: CIPH-QRLW3-29-31

### DIFF
--- a/src/providers/BaseProvider.ts
+++ b/src/providers/BaseProvider.ts
@@ -70,9 +70,23 @@ export type BaseProviderState = {
 export abstract class BaseProvider extends SafeEventEmitter {
   protected readonly _log: ConsoleLike;
 
-  protected _state: BaseProviderState;
+  // Truly private (ES2022 `#`-private). Page scripts holding a reference
+  // to the provider can no longer read or mutate provider state via
+  // `provider._state`. Subclasses access the two state flags they need
+  // through the protected getters below.
+  #state: BaseProviderState;
 
   protected _rpcEngine: JsonRpcEngine;
+
+  /** Read-only view of `#state.isConnected` for subclasses. */
+  protected get _isConnected(): boolean {
+    return this.#state.isConnected;
+  }
+
+  /** Read-only view of `#state.initialized` for subclasses. */
+  protected get _isInitialized(): boolean {
+    return this.#state.initialized;
+  }
 
   protected static _defaultState: BaseProviderState = {
     accounts: null,
@@ -116,7 +130,7 @@ export abstract class BaseProvider extends SafeEventEmitter {
     this.setMaxListeners(maxEventListeners);
 
     // Private state
-    this._state = {
+    this.#state = {
       ...BaseProvider._defaultState,
     };
 
@@ -164,7 +178,7 @@ export abstract class BaseProvider extends SafeEventEmitter {
    * @returns Whether the provider can process RPC requests.
    */
   isConnected(): boolean {
-    return this._state.isConnected;
+    return this.#state.isConnected;
   }
 
   /**
@@ -247,7 +261,7 @@ export abstract class BaseProvider extends SafeEventEmitter {
     isUnlocked: boolean;
     networkVersion?: string;
   }) {
-    if (this._state.initialized) {
+    if (this.#state.initialized) {
       throw new Error("Provider already initialized.");
     }
 
@@ -263,7 +277,7 @@ export abstract class BaseProvider extends SafeEventEmitter {
 
     // Mark provider as initialized regardless of whether initial state was
     // retrieved.
-    this._state.initialized = true;
+    this.#state.initialized = true;
     this.emit("_initialized");
   }
 
@@ -315,8 +329,8 @@ export abstract class BaseProvider extends SafeEventEmitter {
    * @fires QrlWalletInpageProvider#connect
    */
   protected _handleConnect(chainId: string) {
-    if (!this._state.isConnected) {
-      this._state.isConnected = true;
+    if (!this.#state.isConnected) {
+      this.#state.isConnected = true;
       this.emit("connect", { chainId });
       this._log.debug(messages.info.connected(chainId));
     }
@@ -335,10 +349,10 @@ export abstract class BaseProvider extends SafeEventEmitter {
    */
   protected _handleDisconnect(isRecoverable: boolean, errorMessage?: string) {
     if (
-      this._state.isConnected ||
-      (!this._state.isPermanentlyDisconnected && !isRecoverable)
+      this.#state.isConnected ||
+      (!this.#state.isPermanentlyDisconnected && !isRecoverable)
     ) {
-      this._state.isConnected = false;
+      this.#state.isConnected = false;
 
       let error;
       if (isRecoverable) {
@@ -354,10 +368,10 @@ export abstract class BaseProvider extends SafeEventEmitter {
         );
         this._log.error(error);
         this.#chainId = null;
-        this._state.accounts = null;
+        this.#state.accounts = null;
         this.#selectedAddress = null;
-        this._state.isUnlocked = false;
-        this._state.isPermanentlyDisconnected = true;
+        this.#state.isUnlocked = false;
+        this.#state.isPermanentlyDisconnected = true;
       }
 
       this.emit("disconnect", error);
@@ -390,7 +404,7 @@ export abstract class BaseProvider extends SafeEventEmitter {
 
     if (chainId !== this.#chainId) {
       this.#chainId = chainId;
-      if (this._state.initialized) {
+      if (this.#state.initialized) {
         this.emit("chainChanged", this.#chainId);
       }
     }
@@ -431,17 +445,17 @@ export abstract class BaseProvider extends SafeEventEmitter {
     }
 
     // emit accountsChanged if anything about the accounts array has changed
-    if (!dequal(this._state.accounts, _accounts)) {
+    if (!dequal(this.#state.accounts, _accounts)) {
       // we should always have the correct accounts even before eth_accounts
       // returns
-      if (isEthAccounts && this._state.accounts !== null) {
+      if (isEthAccounts && this.#state.accounts !== null) {
         this._log.error(
           `QrlWallet: 'eth_accounts' unexpectedly updated accounts. Please report this bug.`,
           _accounts,
         );
       }
 
-      this._state.accounts = _accounts as string[];
+      this.#state.accounts = _accounts as string[];
 
       // handle selectedAddress
       if (this.#selectedAddress !== _accounts[0]) {
@@ -449,7 +463,7 @@ export abstract class BaseProvider extends SafeEventEmitter {
       }
 
       // finally, after all state has been updated, emit the event
-      if (this._state.initialized) {
+      if (this.#state.initialized) {
         const _nextAccounts = [..._accounts];
         this.emit("accountsChanged", _nextAccounts);
       }
@@ -479,8 +493,8 @@ export abstract class BaseProvider extends SafeEventEmitter {
       return;
     }
 
-    if (isUnlocked !== this._state.isUnlocked) {
-      this._state.isUnlocked = isUnlocked;
+    if (isUnlocked !== this.#state.isUnlocked) {
+      this.#state.isUnlocked = isUnlocked;
       this._handleAccountsChanged(accounts ?? []);
     }
   }

--- a/src/providers/QrlWalletInpageProvider.test.ts
+++ b/src/providers/QrlWalletInpageProvider.test.ts
@@ -416,7 +416,7 @@ describe("QrlWalletInpageProvider: RPC", () => {
 
         connectionStream.notify(QrlWalletInpageProviderStreamName, {
           jsonrpc: "2.0",
-          method: "metamask_chainChanged",
+          method: "qrlWallet_chainChanged",
           params: { chainId: "0x1", networkVersion: "1" },
         });
       });
@@ -433,7 +433,7 @@ describe("QrlWalletInpageProvider: RPC", () => {
 
         connectionStream.notify(QrlWalletInpageProviderStreamName, {
           jsonrpc: "2.0",
-          method: "metamask_chainChanged",
+          method: "qrlWallet_chainChanged",
           params: { chainId: "0x1", networkVersion: "1" },
         });
       });
@@ -457,7 +457,7 @@ describe("QrlWalletInpageProvider: RPC", () => {
 
         connectionStream.notify(QrlWalletInpageProviderStreamName, {
           jsonrpc: "2.0",
-          method: "metamask_chainChanged",
+          method: "qrlWallet_chainChanged",
           // A "loading" networkVersion indicates the network is changing.
           // Although the chainId is different, chainChanged should not be
           // emitted in this case.
@@ -482,7 +482,7 @@ describe("QrlWalletInpageProvider: RPC", () => {
 
         connectionStream.notify(QrlWalletInpageProviderStreamName, {
           jsonrpc: "2.0",
-          method: "metamask_chainChanged",
+          method: "qrlWallet_chainChanged",
           params: { chainId: "0x1", networkVersion: "1" },
         });
       });
@@ -722,11 +722,13 @@ describe("QrlWalletInpageProvider: Miscellanea", () => {
 
       expect(provider.isConnected()).toBe(false);
 
-      provider._state.isConnected = true;
+      // Drive state changes through the protected lifecycle handlers
+      // rather than poking at the now-truly-private #state directly.
+      provider._handleConnect("0x1");
 
       expect(provider.isConnected()).toBe(true);
 
-      provider._state.isConnected = false;
+      provider._handleDisconnect(true);
 
       expect(provider.isConnected()).toBe(false);
     });

--- a/src/providers/QrlWalletInpageProvider.ts
+++ b/src/providers/QrlWalletInpageProvider.ts
@@ -119,9 +119,9 @@ export class QrlWalletInpageProvider extends AbstractStreamProvider {
     // networkVersion is 'loading'.
     super._handleChainChanged({ chainId, networkVersion });
 
-    if (this._state.isConnected && networkVersion !== this.#networkVersion) {
+    if (this._isConnected && networkVersion !== this.#networkVersion) {
       this.#networkVersion = networkVersion as string;
-      if (this._state.initialized) {
+      if (this._isInitialized) {
         this.emit("networkChanged", this.#networkVersion);
       }
     }

--- a/src/providers/StreamProvider.test.ts
+++ b/src/providers/StreamProvider.test.ts
@@ -396,7 +396,7 @@ describe("StreamProvider", () => {
 
           mockStream.notify(mockStreamName, {
             jsonrpc: "2.0",
-            method: "metamask_chainChanged",
+            method: "qrlWallet_chainChanged",
             params: { chainId: "0x1", networkVersion: "0x1" },
           });
         });
@@ -436,7 +436,7 @@ describe("StreamProvider", () => {
 
           mockStream.notify(mockStreamName, {
             jsonrpc: "2.0",
-            method: "metamask_chainChanged",
+            method: "qrlWallet_chainChanged",
             // A "loading" networkVersion indicates the network is changing.
             // Although the chainId is different, chainChanged should not be
             // emitted in this case.
@@ -460,7 +460,7 @@ describe("StreamProvider", () => {
 
           mockStream.notify(mockStreamName, {
             jsonrpc: "2.0",
-            method: "metamask_chainChanged",
+            method: "qrlWallet_chainChanged",
             // The networkVersion will be ignored here, we're just setting it
             // to something other than 'loading'.
             params: { chainId: "0x1", networkVersion: "1" },

--- a/src/providers/StreamProvider.ts
+++ b/src/providers/StreamProvider.ts
@@ -92,21 +92,26 @@ export abstract class AbstractStreamProvider extends BaseProvider {
     // Wire up the JsonRpcEngine to the JSON-RPC connection stream
     this._rpcEngine.push(this._jsonRpcConnection.middleware);
 
-    // Handle JSON-RPC notifications
+    // Handle JSON-RPC notifications. Notification names are the QRL
+    // wallet's own (`qrlWallet_*` / `QRL_WALLET_STREAM_FAILURE`).
+    // Legacy `metamask_*` aliases inherited from the upstream fork
+    // were retired prior to first stable release; the only consumer
+    // (`qrl-web3-wallet`) never emitted them, so dropping them
+    // narrows the public surface without breaking compatibility.
     this._jsonRpcConnection.events.on("notification", (payload) => {
       const { method, params } = payload;
-      if (method === "metamask_accountsChanged") {
+      if (method === "qrlWallet_accountsChanged") {
         this._handleAccountsChanged(params);
-      } else if (method === "metamask_unlockStateChanged") {
+      } else if (method === "qrlWallet_unlockStateChanged") {
         this._handleUnlockStateChanged(params);
-      } else if (method === "metamask_chainChanged") {
+      } else if (method === "qrlWallet_chainChanged") {
         this._handleChainChanged(params);
       } else if (EMITTED_NOTIFICATIONS.includes(method)) {
         this.emit("message", {
           type: method,
           data: params,
         });
-      } else if (method === "METAMASK_STREAM_FAILURE") {
+      } else if (method === "QRL_WALLET_STREAM_FAILURE") {
         connectionStream.destroy(
           new Error(messages.errors.permanentlyDisconnected())
         );

--- a/src/providers/messages.ts
+++ b/src/providers/messages.ts
@@ -40,7 +40,7 @@ const messages = {
       walletWatchAssetNFTExperimental: `QrlWallet: The RPC method 'wallet_watchAsset' is experimental for ERC721/ERC1155 assets and may change in the future.`,
     },
     // misc
-    experimentalMethods: `QrlWallet: 'ethereum._metamask' exposes non-standard, experimental methods. They may be removed or changed without warning.`,
+    experimentalMethods: `QrlWallet: 'ethereum._qrlWallet' exposes non-standard, experimental methods. They may be removed or changed without warning.`,
   },
 };
 export default messages;

--- a/src/providers/siteMetadata.ts
+++ b/src/providers/siteMetadata.ts
@@ -21,7 +21,7 @@ export async function sendSiteMetadata(
       {
         jsonrpc: "2.0",
         id: 1,
-        method: "metamask_sendDomainMetadata",
+        method: "qrlWallet_sendDomainMetadata",
         params: domainMetadata,
       },
       NOOP,


### PR DESCRIPTION
CIPH-QRLW3-29	INFO	Provider emits residual metamask_* notification names

CIPH-QRLW3-30	INFO	_metamask namespace exposed on provider object

CIPH-QRLW3-31	INFO	Provider _state is plain instance property, not WeakMap-private